### PR TITLE
docs: update README for web interface setup

### DIFF
--- a/packages/morph/README.md
+++ b/packages/morph/README.md
@@ -1,3 +1,58 @@
-## web-interface for `tinymorph`
+# Tinymorph Web Interface
 
---wip--
+The web-based interface for `tinymorph`, designed to assist users in editing and receiving effective suggestions for improving their writing.
+
+## Getting Started
+
+Follow these steps to set up and run the project locally.
+
+### Prerequisites
+
+Ensure you have the following installed:
+
+- [Node.js](https://nodejs.org/) (version 16 or higher recommended)
+- [npm](https://www.npmjs.com/) (comes bundled with Node.js)
+
+### Installation
+
+1. Clone the Repository
+
+   ```
+   git clone https://github.com/your-username/tinymorph.git
+2. Open the folder where the repository was cloned, then navigate to the `morph` Package:
+
+   ```
+   cd packages/morph
+   ```
+
+3. Install Dependencies
+   ```
+   npm install
+   ```
+
+### Running the Project
+
+1. Start the Development Server
+
+   ```
+   npm run dev
+   ``` 
+
+2. Open in Browser by visiting the application at [http://localhost:5173](http://localhost:5173)
+
+### Building for Production
+
+To create an optimized production build, run the following command:
+```
+npm run build
+```
+
+<br>
+
+This guide provides the steps necessary to set up, run, and build the `tinymorph` web interface locally for development or deployment.
+
+
+
+
+
+

--- a/packages/morph/src/page/Editor/NotesPanel.tsx
+++ b/packages/morph/src/page/Editor/NotesPanel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 interface Note {
   id: number;
   title: string;

--- a/packages/morph/src/page/Editor/Workspace.tsx
+++ b/packages/morph/src/page/Editor/Workspace.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { EditorState } from "@codemirror/state";
 import { EditorView, basicSetup } from "codemirror";
 import { markdown } from "@codemirror/lang-markdown";


### PR DESCRIPTION
Improved README with clear instructions for setting up and running the `tinymorph` web interface locally.