### PR TITLE
chore(notes): enhance notes panel styling, layout, and add graph properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
+lib/
+!packages/morph/lib/
 lib64/
 parts/
 sdist/

--- a/packages/morph/src/lib/utils.ts
+++ b/packages/morph/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/packages/morph/src/page/Editor/NotesPanel.tsx
+++ b/packages/morph/src/page/Editor/NotesPanel.tsx
@@ -1,28 +1,104 @@
+interface DataPoint {
+  x: string;
+  y: number;
+}
+
 interface Note {
   id: number;
   title: string;
   content: string;
+  graph?: DataPoint[];
 }
 
 const sampleNotes: Note[] = [
-  { id: 1, title: "Note 1", content: "This is the first note." },
-  { id: 2, title: "Note 2", content: "This is the second note." },
-  { id: 3, title: "Note 3", content: "This is the third note." },
-  { id: 4, title: "Note 4", content: "This is the fourth note." },
-  { id: 5, title: "Note 5", content: "This is the fifth note." }
+  { 
+    id: 1, 
+    title: "Note 1", 
+    content: "This is the first note. It provides overview of important details.",
+    graph: [
+      { x: 'a', y: 0.2 },
+      { x: 'b', y: 0.5 },
+      { x: 'c', y: 0.3 },
+      { x: 'd', y: 0.8 },
+    ]
+  },
+  { 
+    id: 2, 
+    title: "Note 2", 
+    content: "This is the second note, and it includes slightly more details about the topic.",
+    graph: [
+      { x: 'a', y: 0.5 },
+      { x: 'b', y: 0.7 },
+      { x: 'c', y: 0.6 },
+      { x: 'd', y: 0.4 },
+    ]
+  },
+  { 
+    id: 3, 
+    title: "Note 3", 
+    content: "This is the third note. It's concise and straight to the point.",
+    graph: [
+      { x: 'a', y: 0.3 },
+      { x: 'b', y: 0.4 },
+      { x: 'c', y: 0.6 },
+      { x: 'd', y: 0.8 },
+    ]
+  },
+  { 
+    id: 4, 
+    title: "Note 4", 
+    content: "This is the fourth note. Here, we discuss some related ideas without going too in depth.",
+    graph: [
+      { x: 'a', y: 0.1 },
+      { x: 'b', y: 0.3 },
+      { x: 'c', y: 0.5 },
+      { x: 'd', y: 0.4 },
+    ]
+  },
+  { 
+    id: 5, 
+    title: "Note 5", 
+    content: "This is the fifth note. It's much shorter than the others.",
+    graph: [
+      { x: 'a', y: 0.4 },
+      { x: 'b', y: 0.6 },
+      { x: 'c', y: 0.8 },
+      { x: 'd', y: 0.7 },
+    ]
+  }
 ];
 
+
 export function NotesPanel() {
+  const leftColumnNotes = sampleNotes.filter((_, index) => index % 2 === 0);
+  const rightColumnNotes = sampleNotes.filter((_, index) => index % 2 === 1);
+
   return (
     <div className="notes-panel">
       <h2 className="text-xl font-bold mb-4">Notes</h2>
-      <div className="space-y-4">
-        {sampleNotes.map((note) => (
-          <div key={note.id} className="border-b pb-3">
-            <h3 className="font-semibold mb-1">{note.title}</h3>
-            <p className="text-sm text-gray-600">{note.content}</p>
-          </div>
-        ))}
+      <div className="notes-columns">
+        <div className="notes-column">
+          {leftColumnNotes.map((note) => (
+            <div 
+              key={note.id} 
+              className="note-item"
+            >
+              <h3 className="font-semibold mb-2">{note.title}</h3>
+              <p className="text-sm text-gray-600">{note.content}</p>
+            </div>
+          ))}
+        </div>
+        <div className="notes-column">
+          {rightColumnNotes.map((note) => (
+            <div 
+              key={note.id} 
+              className="note-item"
+            >
+              <h3 className="font-semibold mb-2">{note.title}</h3>
+              <p className="text-sm text-gray-600">{note.content}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/packages/morph/src/page/Editor/Workspace.tsx
+++ b/packages/morph/src/page/Editor/Workspace.tsx
@@ -43,7 +43,7 @@ This is **bold** text.
 
   return (
     <div className="editor-container">
-      <div className="flex justify-end items-center gap-2 mb-2 mr-3">
+      <div className="flex justify-end items-center gap-2 mb-2 mr-4">
         <Button
           variant="outline"
           onClick={() => setShowNotes(!showNotes)}

--- a/packages/morph/src/styles/editor.scss
+++ b/packages/morph/src/styles/editor.scss
@@ -108,13 +108,17 @@ $blockquote-text-color: #555555;
 }
 
 .editor-container {
-  .toolbar {
-    margin-bottom: 0.5rem;
-  }
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 1rem;
 
   .editor-content {
     display: flex;
     gap: 1rem;
+    margin-right: 1rem;
+    flex: 1;
+    min-height: 0;
 
     .editor {
       flex: 1;
@@ -130,8 +134,64 @@ $blockquote-text-color: #555555;
   .notes-panel {
     width: 25%;
     padding: 1rem;
-    border-left: 1px solid #cccccc;
-    overflow-y: auto;
-    max-height: calc(100vh - 4rem);
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 4rem);
+    min-height: 400px;
+    position: sticky;
+    top: 1rem;
+    
+    h2 {
+      margin-bottom: 1rem;
+      flex-shrink: 0;
+    }
+    
+    .notes-columns {
+      display: flex;
+      gap: 1rem;
+      overflow-y: auto;
+      flex: 1;
+      padding-right: 0.5rem;
+      
+      .notes-column {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+    }
+    
+    .note-item {
+      background-color: white;
+      border-radius: 0.5rem;
+      padding: 1rem;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      transform: translateZ(0);
+      transition: transform 0.2s ease;
+    }
+    
+    .note-item:hover {
+      transform: translateY(-0.25rem);
+    }
+    
+    .notes-columns::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    .notes-columns::-webkit-scrollbar-track {
+      background: #f1f1f1;
+      border-radius: 3px;
+    }
+
+    .notes-columns::-webkit-scrollbar-thumb {
+      background: #cccccc;
+      border-radius: 3px;
+    }
+
+    .notes-columns::-webkit-scrollbar-thumb:hover {
+      background: #bbbbbb;
+    }
   }
 }

--- a/packages/morph/src/styles/editor.scss
+++ b/packages/morph/src/styles/editor.scss
@@ -154,6 +154,24 @@ $blockquote-text-color: #555555;
       overflow-y: auto;
       flex: 1;
       padding-right: 0.5rem;
+
+      &::-webkit-scrollbar {
+        width: 6px;
+      }
+  
+      &::-webkit-scrollbar-track {
+        background: #f1f1f1;
+        border-radius: 3px;
+      }
+  
+      &::-webkit-scrollbar-thumb {
+        background: #cccccc;
+        border-radius: 3px;
+  
+        &:hover {
+          background: #bbbbbb;
+        }
+      }
       
       .notes-column {
         flex: 1;
@@ -174,24 +192,6 @@ $blockquote-text-color: #555555;
     
     .note-item:hover {
       transform: translateY(-0.25rem);
-    }
-    
-    .notes-columns::-webkit-scrollbar {
-      width: 6px;
-    }
-
-    .notes-columns::-webkit-scrollbar-track {
-      background: #f1f1f1;
-      border-radius: 3px;
-    }
-
-    .notes-columns::-webkit-scrollbar-thumb {
-      background: #cccccc;
-      border-radius: 3px;
-    }
-
-    .notes-columns::-webkit-scrollbar-thumb:hover {
-      background: #bbbbbb;
     }
   }
 }


### PR DESCRIPTION
### Overview
- Redesigned the notes panel with a two-column masonry layout for better organization and readability of notes.
- Added a slider for scrollable notes, ensuring all notes fit within the screen without overflowing.
- Introduced a notes container to ensure consistent styling and structure.
- Extended the `Note` objects to include graph properties for future reference and potential dynamic graph rendering (graphs are not displayed yet).
- Adjusted `.gitignore` to exclude only the root `lib` directory while allowing `lib` under packages/morph to allow proper usage of `utils.ts` without errors.

These changes enhance the usability and future potential of the notes panel while maintaining its current functionality.