### PR TITLE
feat(editor): enable vim keybindings to the editor

### DIFF
--- a/packages/morph/package-lock.json
+++ b/packages/morph/package-lock.json
@@ -12,6 +12,7 @@
         "@codemirror/state": "^6.5.0",
         "@codemirror/view": "^6.36.1",
         "@radix-ui/react-slot": "^1.1.1",
+        "@replit/codemirror-vim": "^6.2.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "codemirror": "^6.0.1",
@@ -1636,6 +1637,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@replit/codemirror-vim": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.2.1.tgz",
+      "integrity": "sha512-qDAcGSHBYU5RrdO//qCmD8K9t6vbP327iCj/iqrkVnjbrpFhrjOt92weGXGHmTNRh16cUtkUZ7Xq7rZf+8HVow==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.1.0",
+        "@codemirror/search": "^6.2.0",
+        "@codemirror/state": "^6.0.1",
+        "@codemirror/view": "^6.0.3"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -14,6 +14,7 @@
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.36.1",
     "@radix-ui/react-slot": "^1.1.1",
+    "@replit/codemirror-vim": "^6.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "codemirror": "^6.0.1",

--- a/packages/morph/src/page/Editor/Workspace.tsx
+++ b/packages/morph/src/page/Editor/Workspace.tsx
@@ -6,6 +6,7 @@ import { inlineMarkdownExtension } from "./MarkdownRenderer";
 import { NotesPanel } from "./NotesPanel";
 import { MarkdownFileUpload } from "./MarkdownFileUpload";
 import { Button } from "@/components/ui/button";
+import { vim } from "@replit/codemirror-vim";
 
 export function Workspace() {
   const [showNotes, setShowNotes] = useState(false);
@@ -20,12 +21,12 @@ export function Workspace() {
 
 This is **bold** text.
 
-[[Wikilink Test]]
-`,
+[[Wikilink Test]]`,
       extensions: [
         basicSetup,
         markdown(),
-        inlineMarkdownExtension
+        inlineMarkdownExtension,
+        vim()
       ]
     });
 
@@ -43,7 +44,7 @@ This is **bold** text.
 
   return (
     <div className="editor-container">
-      <div className="flex justify-end items-center gap-2 mb-2 mr-4">
+      <div className="flex justify-end items-center gap-2 mb-4 mt-2 mr-4">
         <Button
           variant="outline"
           onClick={() => setShowNotes(!showNotes)}

--- a/packages/morph/src/styles/editor.scss
+++ b/packages/morph/src/styles/editor.scss
@@ -194,7 +194,7 @@ html {
     border-radius: 8px;
     display: flex;
     flex-direction: column;
-    height: calc(100vh - 4rem);
+    height: calc(100vh - 4.8rem);
     min-height: 400px;
     position: sticky;
     top: 1rem;


### PR DESCRIPTION
Added Vim keybindings into the editor using `@replit/codemirror-vim`, enhancing navigation and editing for users familiar with Vim commands.

This update includes integrating Vim keybindings into the editor's configuration within the `Workspace` component and making minor height adjustments to the notes panel for better alignment and usability.