### PR TITLE
feat(notes): add note drag-and-drop functionality with console display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ venv/
 _version.py
 target
 .env
+node_modules

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -22,6 +22,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "codemirror": "^6.0.1",
+    "d3-drag": "^3.0.0",
+    "d3-selection": "^3.0.0",
     "lucide-react": "^0.469.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -35,10 +37,13 @@
     "sass": "^1.83.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "vfile": "^6.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@types/d3-drag": "^3.0.7",
+    "@types/d3-selection": "^3.0.11",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",

--- a/packages/morph/src/page/Editor/NotesPanel.tsx
+++ b/packages/morph/src/page/Editor/NotesPanel.tsx
@@ -1,11 +1,6 @@
-import React, { useRef, useState, useEffect, RefObject } from 'react';
+import { useRef, useState, useEffect, RefObject } from 'react';
 import { drag } from 'd3-drag';
 import { select } from 'd3-selection';
-
-interface DataPoint {
-  x: string;
-  y: number;
-}
 
 export interface Note {
   id: number;
@@ -13,6 +8,22 @@ export interface Note {
   content: string;
   graph?: DataPoint[];
 }
+
+interface DataPoint {
+  x: string;
+  y: number;
+}
+
+interface DraggableNoteProps {
+  note: Note;
+  editorRef: RefObject<HTMLDivElement>;
+  onDrop: (note: Note, droppedOverEditor: boolean) => void;
+}
+
+interface NotesPanelProps {
+  editorRef: RefObject<HTMLDivElement>;
+}
+
 
 const sampleNotes: Note[] = [
   { 
@@ -72,12 +83,6 @@ const sampleNotes: Note[] = [
   }
 ];
 
-interface DraggableNoteProps {
-  note: Note;
-  editorRef: RefObject<HTMLDivElement>;
-  onDrop: (note: Note, droppedOverEditor: boolean) => void;
-}
-
 function DraggableNote({ note, editorRef, onDrop }: DraggableNoteProps) {
   const noteRef = useRef<HTMLDivElement>(null);
   const [dragging, setDragging] = useState(false);
@@ -89,7 +94,7 @@ function DraggableNote({ note, editorRef, onDrop }: DraggableNoteProps) {
     if (noteRef.current) {
       setFixedWidth(noteRef.current.offsetWidth);
 
-      const dragBehavior = drag<HTMLDivElement, any>()
+      const dragBehavior = drag<HTMLDivElement, unknown>()
         .on("start", (event) => {
           const rect = noteRef.current!.getBoundingClientRect();
           offsetRef.current = {
@@ -163,24 +168,21 @@ function DraggableNote({ note, editorRef, onDrop }: DraggableNoteProps) {
   );
 }
 
-interface NotesPanelProps {
-  editorRef: RefObject<HTMLDivElement>;
-}
-
 export function NotesPanel({ editorRef }: NotesPanelProps) {
   const [notes, setNotes] = useState<Note[]>(sampleNotes);
-  const [droppedNotes, setDroppedNotes] = useState<Note[][]>([]);
+  const [droppedNotes, setDroppedNotes] = useState<Note[]>([]);
 
   const handleDrop = (droppedNote: Note, droppedOverEditor: boolean) => {
     if (droppedOverEditor) {
       setNotes(prevNotes => prevNotes.filter(note => note.id !== droppedNote.id));
       
-      setDroppedNotes(prev => [...prev, [droppedNote]]);
-
-      console.log("Dropped Notes:", [...droppedNotes, [droppedNote]]);
+      const { graph, ...noteWithoutGraph } = droppedNote;
+      setDroppedNotes(prev => [...prev, noteWithoutGraph]);
+  
+      console.log("Dropped Notes:", [...droppedNotes, noteWithoutGraph]);
     }
   };
-
+  
   const leftColumnNotes = notes.filter((_, index) => index % 2 === 0);
   const rightColumnNotes = notes.filter((_, index) => index % 2 === 1);
 

--- a/packages/morph/src/page/Editor/Workspace.tsx
+++ b/packages/morph/src/page/Editor/Workspace.tsx
@@ -24,6 +24,7 @@ This is **bold** text.
 [[Wikilink Test]]`,
       extensions: [
         basicSetup,
+        EditorView.lineWrapping,
         markdown(),
         inlineMarkdownExtension,
         vim()
@@ -54,8 +55,8 @@ This is **bold** text.
         <MarkdownFileUpload editorView={editorView} />
       </div>
       <div className={`editor-content ${showNotes ? 'with-notes' : ''}`}>
-        <div className="editor" ref={editorRef} />
-        {showNotes && <NotesPanel />}
+        <div className="editor" ref={editorRef} data-editor-container="true" />
+        {showNotes && <NotesPanel editorRef={editorRef} />}
       </div>
     </div>
   );

--- a/packages/morph/src/styles/editor.scss
+++ b/packages/morph/src/styles/editor.scss
@@ -211,6 +211,7 @@ html {
       overflow-y: auto;
       flex: 1;
       padding-right: 0.5rem;
+      
 
       &::-webkit-scrollbar {
         width: 6px;
@@ -249,8 +250,5 @@ html {
       font-weight: $normalWeight;
     }
 
-    .note-item:hover {
-      transform: translateY(-0.25rem);
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,12 @@ importers:
       codemirror:
         specifier: ^6.0.1
         version: 6.0.1
+      d3-drag:
+        specifier: ^3.0.0
+        version: 3.0.0
+      d3-selection:
+        specifier: ^3.0.0
+        version: 3.0.0
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@18.3.1)
@@ -296,10 +302,19 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.17.0
+      '@types/d3-drag':
+        specifier: ^3.0.7
+        version: 3.0.7
+      '@types/d3-selection':
+        specifier: ^3.0.11
+        version: 3.0.11
       '@types/node':
         specifier: ^22.10.2
         version: 22.10.4
@@ -3205,6 +3220,7 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
+    requiresBuild: true
 
   /devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -5048,6 +5064,7 @@ packages:
 
   /node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+    requiresBuild: true
 
   /node-fetch@2.6.13:
     resolution: {integrity: sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==}


### PR DESCRIPTION
### Overview

1. **Note Drag-and-Drop Functionality**:
   - Users can drag notes from the Notes Panel and drop them into the editor.
   - Dropped notes are removed from the Notes Panel to prevent duplication.
   - When a note is dropped, its details are logged in the console, excluding the `graph` property.
   - 
2. **Line Wrapping in Editor**:
   - Ensures text content wraps within the editor's width, improving readability and user experience.

These updates enhance usability, streamline the note management workflow, and set what is needed for future improvements to the notes and editor.