### PR TITLE
feat(editor): toggle functionality for Vim binding in settings

### DIFF
--- a/packages/morph/src/page/Editor/Settings.tsx
+++ b/packages/morph/src/page/Editor/Settings.tsx
@@ -16,10 +16,19 @@ import {
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 
-const Settings = () => {
+interface SettingsProps {
+  onVimBindingToggle: (enabled: boolean) => void;
+}
+
+const Settings: React.FC<SettingsProps> = ({ onVimBindingToggle }) => {
   const [activeTab, setActiveTab] = useState("general");
   const [vimBinding, setVimBinding] = useState(false);
   const [theme, setTheme] = useState("system");
+
+  const handleVimBindingChange = (checked: boolean) => {
+    setVimBinding(checked);
+    onVimBindingToggle(checked);
+  };
 
   return (
     <Dialog>
@@ -70,7 +79,7 @@ const Settings = () => {
                   <span>Vim Binding</span>
                   <Switch
                     checked={vimBinding}
-                    onCheckedChange={setVimBinding}
+                    onCheckedChange={handleVimBindingChange}
                   />
                 </div>
               </div>

--- a/packages/morph/src/page/Editor/Workspace.tsx
+++ b/packages/morph/src/page/Editor/Workspace.tsx
@@ -11,26 +11,37 @@ import Settings from "./Settings";
 
 export function Workspace() {
   const [showNotes, setShowNotes] = useState(false);
+  const [vimBindingEnabled, setVimBindingEnabled] = useState(false);
   const editorRef = useRef<HTMLDivElement>(null);
   const [editorView, setEditorView] = useState<EditorView | null>(null);
 
   useEffect(() => {
     if (!editorRef.current) return;
 
-    const startState = EditorState.create({
-      doc: `## Hello World
+    const currentContent = editorView 
+      ? editorView.state.doc.toString() 
+      : `## Hello World
 
 This is **bold** text.
 
-[[Wikilink Test]]`,
-      extensions: [
-        basicSetup,
-        EditorView.lineWrapping,
-        markdown(),
-        inlineMarkdownExtension,
-        vim(),
-      ],
+[[Wikilink Test]]`;
+
+    const extensions = [
+      basicSetup,
+      EditorView.lineWrapping,
+      markdown(),
+      inlineMarkdownExtension,
+      ...(vimBindingEnabled ? [vim()] : []),
+    ];
+
+    const startState = EditorState.create({
+      doc: currentContent,
+      extensions: extensions,
     });
+
+    if (editorView) {
+      editorView.destroy();
+    }
 
     const view = new EditorView({
       state: startState,
@@ -42,7 +53,11 @@ This is **bold** text.
     return () => {
       view.destroy();
     };
-  }, []);
+  }, [vimBindingEnabled]);
+
+  const handleVimBindingToggle = (enabled: boolean) => {
+    setVimBindingEnabled(enabled);
+  };
 
   return (
     <div className="editor-container">
@@ -54,7 +69,7 @@ This is **bold** text.
 
         <MarkdownFileUpload editorView={editorView} />
 
-        <Settings />
+        <Settings onVimBindingToggle={handleVimBindingToggle} />
       </div>
 
       <div className={`editor-content ${showNotes ? "with-notes" : ""}`}>


### PR DESCRIPTION
Enabled users to toggle Vim binding on or off directly from the settings popup. By default, Vim binding is disabled, allowing non-Vim users to work seamlessly. Users can enable Vim binding dynamically, and the editor preserves any existing content when toggling.

This feature enhances user experience by offering flexibility for those who prefer Vim shortcuts while maintaining a clean and intuitive default experience for others.