### PR TITLE
chore(notes): implement draggable and droppable notes with ghost preview

### DIFF
--- a/packages/morph/components/note-card.tsx
+++ b/packages/morph/components/note-card.tsx
@@ -1,14 +1,24 @@
+import { forwardRef } from 'react'
+
 interface NoteCardProps {
   title: string
   content: string
+  style?: React.CSSProperties
 }
 
-export function NoteCard({ title, content }: NoteCardProps) {
-  return (
-    <div className="p-4 bg-card border border-border">
-      <h3 className="mb-2 text-sm font-medium text-foreground">{title}</h3>
-      <p className="text-xs text-muted-foreground leading-relaxed">{content}</p>
-    </div>
-  )
-}
+export const NoteCard = forwardRef<HTMLDivElement, NoteCardProps>(
+  ({ title, content, style }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className="p-4 bg-card border border-border"
+        style={style}
+      >
+        <h3 className="mb-2 text-sm font-medium text-foreground">{title}</h3>
+        <p className="text-xs text-muted-foreground leading-relaxed">{content}</p>
+      </div>
+    )
+  }
+)
 
+NoteCard.displayName = 'NoteCard'

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -28,6 +28,8 @@
     "@uiw/react-codemirror": "^4.23.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "d3-drag": "^3.0.0",
+    "d3-selection": "^3.0.0",
     "lucide-react": "^0.474.0",
     "next": "15.1.6",
     "react": "^19.0.0",
@@ -44,6 +46,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@types/d3-drag": "^3.0.7",
+    "@types/d3-selection": "^3.0.11",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      d3-drag:
+        specifier: ^3.0.0
+        version: 3.0.0
+      d3-selection:
+        specifier: ^3.0.0
+        version: 3.0.0
       lucide-react:
         specifier: ^0.474.0
         version: 0.474.0(react@19.0.0)
@@ -327,6 +333,12 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.2.0
+      '@types/d3-drag':
+        specifier: ^3.0.7
+        version: 3.0.7
+      '@types/d3-selection':
+        specifier: ^3.0.11
+        version: 3.0.11
       '@types/node':
         specifier: ^20
         version: 20.17.16


### PR DESCRIPTION
Reintroduced the drag-and-drop functionality for notes lost during the migration to Next.js.  

- **Draggable Notes:** Users can drag notes and drop them into the editor.  
- **Drop Handling:** Notes dropped in the editor are removed from the panel, while others reset to their original position.  
- **Ghost Note:** Displays a semi-transparent preview while dragging.  

Restores the original functionality with Next.js compatibility.